### PR TITLE
Gallery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Website content
+/data
+/pages

--- a/css/dcgsContent.css
+++ b/css/dcgsContent.css
@@ -95,6 +95,24 @@
   margin-bottom: 0;
 }
 
+.gallery {
+  width: 100%;
+  margin: auto;
+}
+.galleryItem {
+  width: calc(100% / 3);
+}
+.galleryItem-medium {
+  width: calc(100% / 3 * 2);
+}
+.galleryItem-large {
+  width: 100%;
+}
+.galleryItem img {
+  padding: 6px;
+}
+
+
 .setDisplay {
   padding: 0 9px;
 }

--- a/header.php
+++ b/header.php
@@ -75,8 +75,11 @@
   
   <!-- Major JavaScript libraries: at the top for general usage -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.0/jquery.min.js"></script>
+  <script src="https://unpkg.com/imagesloaded@4/imagesloaded.pkgd.min.js"></script>
+  <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
   <script type='text/javascript' src='/modules/js/moment.js'></script>
   <script src="/modules/js/bootstrap.min.js"></script>
+  <script type='text/javascript' src='/modules/js/gallery.js'></script>
   
 </head>
 <body>

--- a/modules/js/gallery.js
+++ b/modules/js/gallery.js
@@ -8,8 +8,8 @@ $(document).ready(function() {
       transitionDuration: 0
 	});
 	// layout Masonry after each image loads
-	$grid.imagesLoaded().progress( function() {
-	  $grid.masonry('layout');
+	$gallery.imagesLoaded().progress( function() {
+	  $gallery.masonry('layout');
 	});
     
 });

--- a/modules/js/gallery.js
+++ b/modules/js/gallery.js
@@ -1,0 +1,15 @@
+$(document).ready(function() {
+
+    // init Masonry
+	var $gallery = $('.gallery').masonry({
+	  	columnWidth: '.gallerySizer',
+  		itemSelector: '.galleryItem',
+  		percentPosition: true,
+      transitionDuration: 0
+	});
+	// layout Masonry after each image loads
+	$grid.imagesLoaded().progress( function() {
+	  $grid.masonry('layout');
+	});
+    
+});

--- a/modules/parsing/images.php
+++ b/modules/parsing/images.php
@@ -24,7 +24,7 @@
         }
       }
     }
-    if (strpos($format,'set') === false) {
+    if (strpos($format,'set') === false && strpos($format, 'gallery') === false) {
       // Build a basic container first and then modify it if there's any formatting
       $container = '<div class="row"><div class="embedFeature col-sm-X col-sm-offset-X">';
       $content = $container.$content.'</div></div>';

--- a/updateParsing.php
+++ b/updateParsing.php
@@ -53,6 +53,13 @@
         } else {
           $c = count($output['content']);
         }
+        if (strpos($row['format'],'gallery') !== false) {
+          if (isset($output['content'][$c-1]['gallery']) && strpos($row['format'],'new') === false) {
+            $gallery = $c-1;
+          } else {
+            $gallery = $c;
+          }
+        }
         if (strpos($row['format'],'set') !== false) {
           if (isset($output['content'][$c-1]['set']) && strpos($row['format'],'new') === false) {
             $set = $c-1;
@@ -98,10 +105,12 @@
             $imageID = makeID($row['url'], 1);
             $images[] = array('id' => $imageID, 'url' => $row['url'], 'content' => $row['content'], 'format' => $row['format']);
             if ($row['format'] != 'hidden') {
-              if (!isset($set)) {
-                $output['content'][] = '[IMAGE:'.$imageID.']';
-              } else {
+              if (isset($set)) {
                 $output['content'][$set]['set'][] = '[IMAGE:'.$imageID.']';
+              } elseif (isset($gallery)) {
+                $output['content'][$gallery]['gallery'][] = array('name' => '[IMAGE:'.$imageID.']', 'format' => $row['format']);
+              } else {
+                $output['content'][] = '[IMAGE:'.$imageID.']';
               }
             }
             if (!empty($row['content'])) {
@@ -245,6 +254,30 @@
           $setHold--;
         }
         $output['page'] .= '</div>';
+      } elseif (isset($block['gallery'])) {
+        $galleryCount = 0;
+        $setBox  = '<div class="col-sm-X">Y</div>';
+        $output['page'] .= '<div class="row gallery">';
+        
+        foreach ($block['gallery'] as $nibble) {
+          $output['page'] .= '<div class="galleryItem';
+          if (strpos($nibble['format'],'medium') !== false) {
+            $output['page'] .= ' galleryItem-medium';
+          } elseif (strpos($nibble['format'],'large') !== false) {
+            $output['page'] .= ' galleryItem-large';
+          } else {
+            $output['page'] .= ' galleryItem-small';
+          }
+          if ($galleryCount == 0 && strpos($nibble['format'],'large') == false && strpos($nibble['format'],'medium') == false) {
+            $output['page'] .= ' gallerySizer';
+            $galleryCount++;
+          }
+          $output['page'] .= '">' . $nibble['name'] .'</div>';
+          
+        }
+
+        $output['page'] .= '</div>';
+
       } else {
         $block = str_replace('&lt;?php ','<?php ',$block); // Makes sure php in code blocks is recognised
         $output['page'] .= $block;


### PR DESCRIPTION
Implementation of a masonry gallery
On the CMS use datatype 'gallery':
- Additionally, use 'medium' and 'large' to create larger images

It is a little fiddly to get looking nice but achievable after a little wiggling.

(also added a .gitignore so that /data and /pages aren't committed)