### PR TITLE
Fix broken MUN link

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -48,7 +48,7 @@ RewriteRule    ^quiz/([^/]+)/([^/]+)/?$            quizSystem.php?author=$1&quiz
 RewriteRule    ^quiz/([^/]+)/([^/]*)/update/?$     quizSystem.php?author=$1&quiz=$2&sync=1  [L]
 
 #External Websites
-RewriteRule    ^mun/?$                http//www.challonersmun.com/                          [L,R=301,NC]
+RewriteRule    ^mun/?$                https://www.challonersmun.com/                          [L,R=301,NC]
 RewriteRule    ^tabletop/?$           https://sites.google.com/challoners.org/tabletop/     [L,R=301,NC]
 RewriteRule    ^tabletop/([^/]+)/?$   https://sites.google.com/challoners.org/tabletop/$1   [L,R=301,NC]
 


### PR DESCRIPTION
There was no colon so the link was broken

Also use the https version (prevents a redirect to the https version for the user as the http version redirects through to https)